### PR TITLE
infra: set backend to static bucket

### DIFF
--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,3 +1,11 @@
 provider "aws" {
   region  = "eu-west-2"
 }
+
+terraform {
+  backend "s3" {
+    bucket = "gneiss-totesys-backend"
+    key    = "application.tfstate"
+    region = "eu-west-2"
+  }
+}


### PR DESCRIPTION
1. Bucket 'gneiss-totesys-backend' created using cli - this has to be outside of terraform.
2. Set the backend up in the provider file.