### PR TITLE
Zips the directory instead of an individual file

### DIFF
--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -4,6 +4,7 @@ data "aws_region" "current" {}
 
 data "archive_file" "lambda" {
   type        = "zip"
-  source_file = "${path.module}/../src/ingestion.py"
+  excludes = [ "__pycache__" ]|
+  source_dir = "${path.module}/../data_ingestion/src/ingestion"
   output_path = "${path.module}/../ingestion_function.zip"
 }

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -3,7 +3,7 @@ resource "aws_lambda_function" "totesys_ingestion" {
   role          = aws_iam_role.lambda_role.arn
   s3_bucket     = aws_s3_bucket.code_bucket.id
   s3_key        = aws_s3_object.lambda_code.key
-  handler       = "ingestion.ingestion_handler"
+  handler       = "ingestion.lambda_handler"
   runtime       = "python3.11"
   layers        = ["arn:aws:lambda:eu-west-2:133256977650:layer:AWS-Parameters-and-Secrets-Lambda-Extension:11",aws_lambda_layer_version.pg8000_layer.arn,aws_lambda_layer_version.temp_boto_layer.arn]
 }


### PR DESCRIPTION
Small change to zip up the dir instead of the file.

Lambda points to the correct entrypoint.