### PR TITLE
fix: set lambda timeout to 60s

### DIFF
--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -5,6 +5,7 @@ resource "aws_lambda_function" "totesys_ingestion" {
   s3_key        = aws_s3_object.lambda_code.key
   handler       = "ingestion.ingestion.lambda_handler"
   runtime       = "python3.11"
+  timeout       = 60 # NOTE this must be less than the period defined in the eventbridge rule
   environment {
     variables = {
       "S3_DATA_ID" = aws_s3_bucket.data_bucket.id,

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -1,6 +1,6 @@
 variable "lambda_name" {
     type = string
-    default = "my_totesys_ingestion"
+    default = "totesys_ingestion"
 }
 
 variable "db_credentials_oltp" {


### PR DESCRIPTION
By default terraform sets the timeout to 3 seconds which is not enough.