### PR TITLE
Fix empty files

### DIFF
--- a/data_ingestion/src/ingestion/write_JSON.py
+++ b/data_ingestion/src/ingestion/write_JSON.py
@@ -30,7 +30,7 @@ def write_to_ingestion(data, bucket):
         current_time = now.strftime("%H:%M:%S")
         s3.put_object(
             Bucket=bucket,
-            Key=f"{table_name}/{date_today}/{current_time}",
+            Key=f"{table_name}/{date_today}/{current_time}.json",
             Body=data)
     except ClientError as c:
         if c.response['Error']['Code'] == 'NoSuchBucket':

--- a/data_ingestion/src/ingestion/write_JSON.py
+++ b/data_ingestion/src/ingestion/write_JSON.py
@@ -1,4 +1,3 @@
-
 import logging
 from botocore.exceptions import ClientError
 import boto3
@@ -21,6 +20,11 @@ def write_to_ingestion(data, bucket):
         s3 = boto3.client('s3', region_name='eu-west-2')
         dict = json.loads(data)
         table_name = dict.get('table_name')
+
+        if dict.get("record_count", 0) == 0:
+            logger.info(f"write_to_ingestion: no records for '{table_name}'.")
+            return
+
         date_today = date.today()
         now = datetime.now()
         current_time = now.strftime("%H:%M:%S")

--- a/data_ingestion/test/ingestion/test_write_to_ingestion.py
+++ b/data_ingestion/test/ingestion/test_write_to_ingestion.py
@@ -6,6 +6,9 @@ import pytest
 from botocore.exceptions import ClientError
 import logging
 from datetime import date as dt
+from unittest.mock import patch
+
+
 logger = logging.getLogger('MyLogger')
 logger.setLevel(logging.ERROR)
 
@@ -85,3 +88,16 @@ def test_function_handles_when_there_is_no_existing_bucket():
         write_to_ingestion(json_data, bucket)
     except ClientError as c:
         assert c.response['Error']['Code'] == 'NoSuchBucket'
+
+
+@patch("ingestion.write_JSON.boto3.client")
+def test_no_file_created_when_there_is_no_new_data(patched_boto3):
+    data_with_no_rows = {
+        "table_name": "sales_order",
+        "column_names": ["a", "b", "c"],
+        "record_count": 0,
+        "rows": []
+    }
+    data_str = json.dumps(data_with_no_rows)
+    write_to_ingestion(data_str, "bucket")
+    patched_boto3.put_object.assert_not_called()


### PR DESCRIPTION
This is to avoid "empty" files being stored when there are no new rows for a table.