### PR TITLE
feat: implementation of date_dim

### DIFF
--- a/json_to_parquet/date_dimension.py
+++ b/json_to_parquet/date_dimension.py
@@ -18,15 +18,7 @@ def date_dimension(start_date: str = '2022-01-01', duration_in_years: int = 5):
         'month_name': [],
         'quarter': []
     }
-    day_to_weekday_map = {
-        'Monday': 1,
-        'Tuesday': 2,
-        'Wednesday': 3,
-        'Thursday': 4,
-        'Friday': 5,
-        'Saturday': 6,
-        'Sunday': 7
-    }
+
     date = dt.fromisoformat(start_date)
 
     days = 365*duration_in_years

--- a/json_to_parquet/date_dimension.py
+++ b/json_to_parquet/date_dimension.py
@@ -1,0 +1,49 @@
+from datetime import datetime as dt
+from datetime import timedelta
+import math
+import pandas as pd
+
+
+def date_dimension(start_date: str = '2022-01-01', duration_in_years: int = 5):
+    ''' start_date='2022-01-01', duration_in_years=5
+
+    Returns a pandas dataframe with every day in the range given.
+    '''
+    dimension = {
+        'year': [],
+        'month': [],
+        'day': [],
+        'day_of_week': [],
+        'day_name': [],
+        'month_name': [],
+        'quarter': []
+    }
+    day_to_weekday_map = {
+        'Monday': 1,
+        'Tuesday': 2,
+        'Wednesday': 3,
+        'Thursday': 4,
+        'Friday': 5,
+        'Saturday': 6,
+        'Sunday': 7
+    }
+    date = dt.fromisoformat(start_date)
+
+    days = 365*duration_in_years
+    for _ in range(days):
+        month_number = date.strftime('%-m')
+        quarter = math.ceil(int(month_number)/3)
+        # quarter = math.ceil(int(month_number)/4)
+
+        dimension['year'].append(int(date.strftime('%Y')))
+        dimension['month'].append(int(date.strftime('%m')))
+        dimension['day'].append(int(date.strftime('%-d')))
+        dimension['day_of_week'].append(int(date.strftime('%w')))
+        dimension['day_name'].append(date.strftime('%A'))
+        dimension['month_name'].append(date.strftime('%B'))
+        dimension['quarter'].append(quarter)
+
+        date += timedelta(days=1)
+    df = pd.DataFrame(dimension)
+
+    return df

--- a/test/json_to_parquet/test_date_dimension.py
+++ b/test/json_to_parquet/test_date_dimension.py
@@ -1,0 +1,57 @@
+from json_to_parquet.date_dimension import date_dimension
+import pandas as pd
+
+
+def test_gets_year_correct():
+    result = date_dimension('2023-11-08', 1)
+    assert result.loc[0, "year"] == 2023
+    assert result.loc[360, "year"] == 2024
+
+
+def test_gets_month_correct():
+    result = date_dimension('2023-11-08', 1)
+    assert result.loc[0, "month"] == 11
+    assert result.loc[30, "month"] == 12
+
+
+def test_gets_day_correct():
+    result = date_dimension('2023-11-08', 1)
+    assert result.loc[0, "day"] == 8
+    assert result.loc[1, "day"] == 9
+
+
+def test_gets_day_of_week_correct():
+    result = date_dimension('2023-11-08', 1)
+    assert result.loc[0, "day_of_week"] == 3
+    assert result.loc[1, "day_of_week"] == 4
+
+
+def test_gets_day_name_correct():
+    result = date_dimension('2023-11-08', 1)
+    assert result.loc[0, "day_name"] == 'Wednesday'
+    assert result.loc[1, "day_name"] == 'Thursday'
+
+
+def test_gets_month_name_correct():
+    result = date_dimension('2023-11-08', 1)
+    assert result.loc[0, "month_name"] == 'November'
+    assert result.loc[30, "month_name"] == 'December'
+
+
+def test_gets_quarter_correct():
+    result = date_dimension('2023-01-01', 1)
+    assert result.loc[0, "quarter"] == 1
+
+    result = date_dimension('2023-04-01', 1)
+    assert result.loc[0, "quarter"] == 2
+
+    result = date_dimension('2023-07-01', 1)
+    assert result.loc[0, "quarter"] == 3
+
+    result = date_dimension('2023-10-01', 1)
+    assert result.loc[0, "quarter"] == 4
+
+
+def test_includes_multiple_rows():
+    result = date_dimension('2023-11-08', 1)
+    assert len(result) == 365

--- a/test/json_to_parquet/test_date_dimension.py
+++ b/test/json_to_parquet/test_date_dimension.py
@@ -1,5 +1,4 @@
 from json_to_parquet.date_dimension import date_dimension
-import pandas as pd
 
 
 def test_gets_year_correct():


### PR DESCRIPTION
date_dimension _optionally_ takes a start date, and a range (in years) for how many dates to populate.
It returns a dataframe with all of the information for that range.

Defaults to 5 years starting with 2022.

It runs fast enough that I don't think quantity of rows is a concern, could do more dates.