### PR TITLE
Logging for loader

### DIFF
--- a/src/ingestion/get_timestamp.py
+++ b/src/ingestion/get_timestamp.py
@@ -1,8 +1,10 @@
 import boto3
 from botocore.exceptions import ClientError
+from utils.custom_log import totesys_logger
 import json
-import logging
 import os
+
+log = totesys_logger()
 
 
 def get_last_ingestion_timestamp():
@@ -18,11 +20,12 @@ def get_last_ingestion_timestamp():
             Key='timestamps.json')
         json_data = response['Body'].read().decode('utf-8')
         timestamp = json.loads(json_data)
+        log.info(f"Timestamp retrieved: {timestamp}")
         return timestamp['last_timestamp']
     except ClientError:
         return "1970-01-01 00:00:00"
     except Exception as e:
-        logging.error(f"Error: {str(e)}")
+        log.error(f"Error: {str(e)}")
         raise e
 
 
@@ -44,6 +47,7 @@ def update_last_ingestion_timestamp(new_timestamp):
             Key='timestamps.json',
             Body=updated_json_data
         )
+        log.info(f"Timestamp stored: {new_timestamp}")
     except Exception as e:
-        logging.error(f'{e}')
+        log.error(f'{e}')
         raise e

--- a/src/json_to_parquet/date_dimension.py
+++ b/src/json_to_parquet/date_dimension.py
@@ -1,10 +1,10 @@
 from datetime import datetime as dt
 from datetime import timedelta
-from utils.custom_log import logger
+from utils.custom_log import totesys_logger
 import math
 import pandas as pd
 
-log = logger(__name__)
+log = totesys_logger()
 
 
 def date_dimension(start_date: str = '2022-01-01',

--- a/src/json_to_parquet/dim_counterparty.py
+++ b/src/json_to_parquet/dim_counterparty.py
@@ -2,8 +2,8 @@ import pandas as pd
 import os
 import json
 from json_to_parquet.get_s3_file import json_from_row_id
-from utils.custom_log import logger
-log = logger(__name__)
+from utils.custom_log import totesys_logger
+log = totesys_logger()
 
 
 def dim_counterparty(data: dict | str) -> pd.DataFrame:

--- a/src/json_to_parquet/dim_staff.py
+++ b/src/json_to_parquet/dim_staff.py
@@ -2,8 +2,8 @@ import pandas as pd
 import os
 import json
 from json_to_parquet.get_s3_file import json_from_row_id
-from utils.custom_log import logger
-log = logger(__name__)
+from utils.custom_log import totesys_logger
+log = totesys_logger()
 
 
 def dim_staff(data: dict | str) -> pd.DataFrame:

--- a/src/json_to_parquet/get_s3_file.py
+++ b/src/json_to_parquet/get_s3_file.py
@@ -1,8 +1,8 @@
 import boto3
 from botocore.exceptions import ClientError
 import json
-from utils.custom_log import logger
-log = logger(__name__)
+from utils.custom_log import totesys_logger
+log = totesys_logger()
 
 
 def json_event(event: dict) -> dict:

--- a/src/json_to_parquet/json_to_parquet.py
+++ b/src/json_to_parquet/json_to_parquet.py
@@ -4,14 +4,14 @@ from json_to_parquet.get_s3_file import json_event, bucket_list
 from json_to_parquet.dim_currency import currency_transform
 from json_to_parquet.date_dimension import date_dimension
 from json_to_parquet.write_pq_to_s3 import write_pq_to_s3
-from utils.custom_log import logger
+from utils.custom_log import totesys_logger
 from json_to_parquet.transformations import (
     transform_address, transform_design,
     transform_sales_order)
 from json_to_parquet.dim_counterparty import dim_counterparty
 from json_to_parquet.dim_staff import dim_staff
 
-log = logger(__name__)
+log = totesys_logger()
 
 
 def fake_fn(data) -> pd.DataFrame:

--- a/src/json_to_parquet/write_pq_to_s3.py
+++ b/src/json_to_parquet/write_pq_to_s3.py
@@ -1,6 +1,6 @@
-from utils.custom_log import logger
+from utils.custom_log import totesys_logger
 from awswrangler import s3
-log = logger(__name__)
+log = totesys_logger()
 
 
 def write_pq_to_s3(bucket: str, key: str, dataframe):

--- a/src/parquet_to_olap/get_parquet_s3_file.py
+++ b/src/parquet_to_olap/get_parquet_s3_file.py
@@ -1,9 +1,9 @@
 from botocore.exceptions import ClientError
 import boto3
 import pandas as pd
-from utils.custom_log import logger
+from utils.custom_log import totesys_logger
 
-log = logger()
+log = totesys_logger()
 
 
 def parquet_event(event: dict):
@@ -30,8 +30,8 @@ def parquet_S3_key(bucket: str, key: str):
         df = pd.read_parquet("/tmp/df.parquet")
         log.info(f"parquet file loaded: {bucket}/{key}")
     except ClientError as e:
-        log.error(f"{e}")
         log.info(f"File: {bucket}/{key} is unavailable")
+        log.error(f"{e}")
         raise (e)
 
     return df

--- a/src/parquet_to_olap/get_parquet_s3_file.py
+++ b/src/parquet_to_olap/get_parquet_s3_file.py
@@ -1,19 +1,9 @@
 from botocore.exceptions import ClientError
-import logging
 import boto3
 import pandas as pd
+from utils.custom_log import logger
 
-
-log = logging.getLogger("get_s3_file")
-log.setLevel(logging.INFO)
-handler = logging.StreamHandler()
-handler.setLevel(logging.INFO)
-log_fmt = logging.Formatter(
-    """%(levelname)s - %(message)s - %(name)s -
-    %(module)s/%(funcName)s()"""
-)
-handler.setFormatter(log_fmt)
-log.addHandler(handler)
+log = logger()
 
 
 def parquet_event(event: dict):
@@ -38,6 +28,7 @@ def parquet_S3_key(bucket: str, key: str):
         with open("/tmp/df.parquet", "wb") as f:
             f.write(data)
         df = pd.read_parquet("/tmp/df.parquet")
+        log.info(f"parquet file loaded: {bucket}/{key}")
     except ClientError as e:
         log.error(f"{e}")
         log.info(f"File: {bucket}/{key} is unavailable")

--- a/src/parquet_to_olap/parquet_to_olap.py
+++ b/src/parquet_to_olap/parquet_to_olap.py
@@ -1,13 +1,13 @@
 from utils.db_credentials import get_credentials
 from utils.pg8000_conn import get_conn
-from utils.custom_log import logger
+from utils.custom_log import totesys_logger
 from parquet_to_olap.get_parquet_s3_file import parquet_event
 from parquet_to_olap.parquet_to_sql_transformation import (
     parquet_to_sql,
     olap_table_names,
 )
 
-log = logger()
+log = totesys_logger()
 
 
 def lambda_handler(event, context):

--- a/src/parquet_to_olap/parquet_to_sql_transformation.py
+++ b/src/parquet_to_olap/parquet_to_sql_transformation.py
@@ -1,8 +1,8 @@
 import pandas as pd
 from pg8000.native import Connection, identifier
-from utils.custom_log import logger
+from utils.custom_log import totesys_logger
 
-log = logger()
+log = totesys_logger()
 
 olap_table_names = {
     "dim_counterparty": "counterparty_id",
@@ -42,7 +42,7 @@ def parquet_to_sql(dataframe, target_table, conn):
 
         for params in params_list:
             log.info(f"Executing query with values: {params}")
-            # conn.run(query_str, **params)
+            conn.run(query_str, **params)
 
         log.info(f"{len(params_list)} rows upserted for table {target_table}")
     except Exception as e:

--- a/src/parquet_to_olap/parquet_to_sql_transformation.py
+++ b/src/parquet_to_olap/parquet_to_sql_transformation.py
@@ -1,17 +1,8 @@
 import pandas as pd
 from pg8000.native import Connection, identifier
-import logging
+from utils.custom_log import logger
 
-log = logging.getLogger("parquet_to_sql_transformation")
-log.setLevel(logging.INFO)
-handler = logging.StreamHandler()
-handler.setLevel(logging.INFO)
-log_fmt = logging.Formatter(
-    """%(levelname)s - %(message)s - %(name)s -
-    %(module)s/%(funcName)s()"""
-)
-handler.setFormatter(log_fmt)
-log.addHandler(handler)
+log = logger()
 
 olap_table_names = {
     "dim_counterparty": "counterparty_id",
@@ -45,13 +36,15 @@ def parquet_to_sql(dataframe, target_table, conn):
         raise TypeError("The conn input is not a valid pg8000 Connection")
     try:
         target_pkey_column = olap_table_names[target_table]
-        query_list = generate_sql_list_for_dataframe(
+        query_str, params_list = generate_sql_list_for_dataframe(
             dataframe, target_table, target_pkey_column
         )
 
-        for item in query_list:
-            query_str, args = item
-            conn.run(query_str, **args)
+        for params in params_list:
+            log.info(f"Executing query with values: {params}")
+            # conn.run(query_str, **params)
+
+        log.info(f"{len(params_list)} rows upserted for table {target_table}")
     except Exception as e:
         log.error(f"{e}")
         raise e
@@ -59,19 +52,20 @@ def parquet_to_sql(dataframe, target_table, conn):
 
 def generate_sql_list_for_dataframe(df, table_name, target_pkey_column):
     """
-    Generates a list of SQL queries for a Pandas DataFrame.
+    Generates a SQL query and list of params from a Pandas DataFrame.
 
     Args:
         dataframe: target dataframe
-        table_name The name of the target table in the database.
+        table_name: The name of the target table in the database.
         target_pkey_column (str): The primary key column.
 
     Returns:
-        list: A list of tuples, each containing two parts:
-              1st: (str) Parametised SQL INSERT statement.
-              2nd: (dict) parameter values to match the insert statement.
-              This output is intended to be consumed by the pg8000.native
-              conn.run method."""
+        tuple: Two elements:
+               1st: (str) Parametised SQL INSERT statement.
+               2nd: (list of dict) parameter values to match the insert
+               statement. This output is intended to be consumed by the
+               pg8000.native conn.run method."""
+
     column_names = [f"{identifier(column)}" for column in df.columns]
     column_str = f"({', '.join(column_names)})"
 
@@ -81,22 +75,22 @@ def generate_sql_list_for_dataframe(df, table_name, target_pkey_column):
     update_columns_str = f"({', '.join(update_columns)})"
     excluded_columns = ["excluded." + column for column in update_columns]
     excluded_str = f"({', '.join(excluded_columns)})"
+    column_symbols = [":" + column for column in column_names]
 
     sql_start = f"INSERT INTO {identifier(table_name)} {column_str} VALUES "
-
+    sql_mid = f'({", ".join(column_symbols)}) '
     sql_end = f"on conflict ({target_pkey_column}) "
     sql_end += f"do update set {update_columns_str} = {excluded_str};"
+    final_sql = sql_start + sql_mid + sql_end
 
-    query_list = []
+    params_list = []
 
     for i in range(len(df)):
         row_values = df.iloc[i, :].values.flatten().tolist()
-        column_symbols = [":" + column for column in column_names]
-        sql_mid = f'({", ".join(column_symbols)}) '
         values_dict = dict(zip(column_names, row_values))
+        params_list.append(values_dict)
 
-        final_sql = sql_start + sql_mid + sql_end
+    log.info(f"Query prepared for dataframe: '{final_sql}'")
+    log.info(f"Parameters prepared for {len(params_list)} records.")
 
-        query_list.append((final_sql, values_dict))
-
-    return query_list
+    return (final_sql, params_list)

--- a/src/utils/custom_log.py
+++ b/src/utils/custom_log.py
@@ -1,7 +1,7 @@
 import logging
 
 
-def logger(name=None):
+def totesys_logger():
     log = logging.getLogger()
     log.setLevel(logging.INFO)
     log.handlers = []  # remove handler provided by AWS
@@ -10,7 +10,7 @@ def logger(name=None):
     handler = logging.StreamHandler()
     handler.setLevel(logging.INFO)
     log_fmt = logging.Formatter(
-        "[%(levelname)s] %(message)s - %(module)s/%(funcName)s() - %(name)s"
+        "[%(levelname)s] %(message)s - %(module)s/%(funcName)s()"
     )
     handler.setFormatter(log_fmt)
 

--- a/src/utils/custom_log.py
+++ b/src/utils/custom_log.py
@@ -1,14 +1,18 @@
 import logging
 
 
-def logger(name):
-    log = logging.getLogger(name)
+def logger(name=None):
+    log = logging.getLogger()
     log.setLevel(logging.INFO)
+    log.handlers = []  # remove handler provided by AWS
+    log.propagate = False
+
     handler = logging.StreamHandler()
     handler.setLevel(logging.INFO)
     log_fmt = logging.Formatter(
-        '''%(levelname)s - %(message)s - %(name)s -
-        %(module)s/%(funcName)s()''')
+        "[%(levelname)s] %(message)s - %(module)s/%(funcName)s() - %(name)s"
+    )
     handler.setFormatter(log_fmt)
+
     log.addHandler(handler)
     return log

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -42,7 +42,7 @@ resource "aws_lambda_function" "json_to_parquet" {
   s3_key        = aws_s3_object.lambda_json_to_parquet_code.key
   handler       = "json_to_parquet.json_to_parquet.lambda_handler"
   runtime       = "python3.11"
-  timeout       = 60
+  timeout       = 600
   environment {
     variables = {
       "S3_DATA_ID"          = aws_s3_bucket.ingestion_bucket.id,
@@ -84,7 +84,7 @@ resource "aws_lambda_function" "parquet_to_OLAP" {
   s3_key        = aws_s3_object.lambda_parquet_to_OLAP_code.key
   handler       = "parquet_to_olap.parquet_to_olap.lambda_handler"
   runtime       = "python3.11"
-  timeout       = 60
+  timeout       = 600
   environment {
     variables = {
       "PARQUET_S3_DATA_ID"  = aws_s3_bucket.transformed_bucket.id,

--- a/test/parquet_to_olap/test_get_parquet_s3_file.py
+++ b/test/parquet_to_olap/test_get_parquet_s3_file.py
@@ -91,13 +91,12 @@ def test_get_logs_error_when_no_bucket(caplog):
     with pytest.raises(ClientError):
         parquet_S3_key("none_bucket", "none_key")
 
-    message_list = caplog.text.split("\n")
-    assert message_list[0][0:5] == "ERROR"
     expected_message = (
         "An error occurred (NoSuchBucket) when calling the GetObject "
         "operation: The specified bucket does not exist"
     )
-    assert caplog.records[0].message == expected_message
+    assert caplog.records[-1].levelname == "ERROR"
+    assert caplog.records[-1].message == expected_message
 
 
 @mock_s3
@@ -110,10 +109,9 @@ def test_get_logs_error_when_no_key(caplog):
     with pytest.raises(ClientError):
         parquet_S3_key("test", "none_key")
 
-    message_list = caplog.text.split("\n")
-    assert message_list[0][0:5] == "ERROR"
     expected_message = (
         "An error occurred (NoSuchKey) when calling the GetObject "
         "operation: The specified key does not exist."
-        )
-    assert caplog.records[0].message == expected_message
+    )
+    assert caplog.records[-1].levelname == "ERROR"
+    assert caplog.records[-1].message == expected_message


### PR DESCRIPTION
Tried to standardise and simplify logging. I haven't really altered what is being put into the logs except for adding a couple of things missing from the parquet-to-olap lambda.

To avoid duplication the default logger handler inserted by AWS behind the scenes is replaced. This stops certain lines being logged twice and ensures all messages go through the same formatter.

Also consolidated all loggers in our code to be the same logger instead of having different names. Not sure if there is any utility in having different instances with their own names kicking about, if anyone has any better understanding or reason to keep them please make a suggestion.

Quick comparison of outputs before and after for the ingestion lambda:
[ingestion_before.log](https://github.com/samule-i/gneiss-totesys/files/13347651/ingestion_before.log)
[ingestion_after.log](https://github.com/samule-i/gneiss-totesys/files/13347653/ingestion_after.log)
