### PR TITLE
fix: timestamps.json was triggering transform

### DIFF
--- a/src/ingestion/get_timestamp.py
+++ b/src/ingestion/get_timestamp.py
@@ -11,11 +11,12 @@ def get_last_ingestion_timestamp():
     Returns:
         str: The last ingestion timestamp for the ingeston lambda
     """
+    timestamp_key = 'timestamps.json.notrigger'
     try:
         s3 = boto3.client('s3', region_name='eu-west-2')
         response = s3.get_object(
             Bucket=os.environ['S3_DATA_ID'],
-            Key='timestamps.json')
+            Key=timestamp_key)
         json_data = response['Body'].read().decode('utf-8')
         timestamp = json.loads(json_data)
         return timestamp['last_timestamp']
@@ -34,6 +35,7 @@ def update_last_ingestion_timestamp(new_timestamp):
     Returns:
         None
     """
+    timestamp_key = 'timestamps.json.notrigger'
     try:
         s3 = boto3.client('s3', region_name='eu-west-2')
         timestamp = {
@@ -41,7 +43,7 @@ def update_last_ingestion_timestamp(new_timestamp):
         updated_json_data = json.dumps(timestamp)
         s3.put_object(
             Bucket=os.environ['S3_DATA_ID'],
-            Key='timestamps.json',
+            Key=timestamp_key,
             Body=updated_json_data
         )
     except Exception as e:

--- a/src/json_to_parquet/json_to_parquet.py
+++ b/src/json_to_parquet/json_to_parquet.py
@@ -52,9 +52,6 @@ def lambda_handler(event, _):
     json_body = json_event(event)
 
     in_key = event['Records'][0]['s3']['object']['key']
-    if in_key == 'timestamps.json':
-        log.info('Key is timestamps, not processing.')
-        return
     try:
         table_name = json_body['table_name']
     except KeyError:

--- a/test/ingestion/test_get_timestamp.py
+++ b/test/ingestion/test_get_timestamp.py
@@ -22,7 +22,7 @@ def s3_boto():
 
 @mock_s3
 def test_valid_table_name(s3_boto):
-    key = 'timestamps.json'
+    key = 'timestamps.json.notrigger'
     data = '{"last_timestamp": "2023-11-05 12:00:00"}'
     location = {'LocationConstraint': 'eu-west-2'}
     s3_boto.create_bucket(
@@ -53,7 +53,7 @@ def test_returns_exception(mock_client):
 
 @mock_s3
 def test_update_timestamp(s3_boto):
-    key = 'timestamps.json'
+    key = 'timestamps.json.notrigger'
     initial_timestamp = '{"last_timestamp": "2023-11-05 12:00:00"}'
     updated_timestamp = '{"last_timestamp": "2023-11-05 13:00:00"}'
     location = {'LocationConstraint': 'eu-west-2'}


### PR DESCRIPTION
timestamps.json was matching the ".json" filter.

Adding a suffix prevents events for 'timestamps.json' happening, whilst keeping the data readable as json.

I used a similar solution [ingestion/write_JSON.py#L53](https://github.com/samule-i/gneiss-totesys/blob/4cb5206d3c5080872144e49a43cf5cbc5b0cc900/src/ingestion/write_JSON.py#L53) and found no issues with reading the file.

timestamps.json is only accessed by the ingestion function, and then is managed solely by the `get_timestamp` file.

The other options are:

  - Continue to handle & ignore the file in the transformation
  - Change the file format to something else, CSV/plaintext

I think this solution is similar to the `.nomedia` files that are used to prevent indexing certain directories in other software.