### PR TITLE
Table correction

### DIFF
--- a/src/json_to_parquet/transformations.py
+++ b/src/json_to_parquet/transformations.py
@@ -232,7 +232,7 @@ def transform_payment(payment_data: str | dict):
         df["created_date"] = df["created_at"].dt.date
         df["created_time"] = df["created_at"].dt.time
         df["last_updated_date"] = df["last_updated"].dt.date
-        df["last_updated_time"] = df["last_updated"].dt.time
+        df["last_updated"] = df["last_updated"].dt.time
 
         df["payment_record_id"] = range(1, 1 + df.shape[0])
 
@@ -242,7 +242,7 @@ def transform_payment(payment_data: str | dict):
             "created_date",
             "created_time",
             "last_updated_date",
-            "last_updated_time",
+            "last_updated",
             "transaction_id",
             "counterparty_id",
             "payment_amount",

--- a/src/json_to_parquet/transformations.py
+++ b/src/json_to_parquet/transformations.py
@@ -282,6 +282,11 @@ def transform_transaction(transaction_data: str | dict):
         ]
 
         dim_transaction = dim_transaction[columns_to_keep]
+        dim_transaction.fillna(0, inplace=True)
+        dim_transaction["purchase_order_id"] = dim_transaction[
+            'purchase_order_id'].astype(int)
+        dim_transaction["sales_order_id"] = dim_transaction[
+            'sales_order_id'].astype(int)
         return dim_transaction
     except Exception as e:
         log.error(f"Error: {str(e)}")

--- a/src/parquet_to_olap/parquet_to_sql_transformation.py
+++ b/src/parquet_to_olap/parquet_to_sql_transformation.py
@@ -72,9 +72,16 @@ def generate_sql_list_for_dataframe(df, table_name, target_pkey_column):
     update_columns = [
         column for column in column_names if column != target_pkey_column
     ]
-    update_columns_str = f"({', '.join(update_columns)})"
+
+    if len(update_columns) == 1:
+        update_columns_str = f"{', '.join(update_columns)}"
+    else:
+        update_columns_str = f"({', '.join(update_columns)})"
     excluded_columns = ["excluded." + column for column in update_columns]
-    excluded_str = f"({', '.join(excluded_columns)})"
+    if len(excluded_columns) == 1:
+        excluded_str = f"{', '.join(excluded_columns)}"
+    else:
+        excluded_str = f"({', '.join(excluded_columns)})"
     column_symbols = [":" + column for column in column_names]
 
     sql_start = f"INSERT INTO {identifier(table_name)} {column_str} VALUES "

--- a/test/json_to_parquet/test_extra_transformations.py
+++ b/test/json_to_parquet/test_extra_transformations.py
@@ -332,7 +332,7 @@ def test_transform_payment_returns_correct_columns_and_rows():
         "created_date",
         "created_time",
         "last_updated_date",
-        "last_updated_time",
+        "last_updated",
         "transaction_id",
         "counterparty_id",
         "payment_amount",
@@ -392,8 +392,8 @@ def test_transform_payment_returns_correct_columns_and_rows():
         'created_time'].astype(str)
     df_payment['last_updated_date'] = df_payment[
         'last_updated_date'].astype(str)
-    df_payment['last_updated_time'] = df_payment[
-        'last_updated_time'].astype(str)
+    df_payment['last_updated'] = df_payment[
+        'last_updated'].astype(str)
     df_payment['payment_date'] = df_payment[
         'payment_date'].astype(
         str)


### PR DESCRIPTION
Adjusted how queries are built due to the fact that parenthesis around a single column causes postgres to throw a tantrum, it seems to see that syntax as some sort of expression when it isn't a list of columns.
![image](https://github.com/samule-i/gneiss-totesys/assets/17341970/32122a1a-ee82-4fc5-bbd4-73fca15c89bb)


Also set null values in transactions to be zero, I attempted to use None/Null, but upon loading a pq file in pandas it seems to set None-like values to be a numpy.NaN type (or pd.NA).

It might be possible to convert NaN values to NULL values in the OLAP loader, but for now I'm doing this here to prevent mixing up responsibilities.
